### PR TITLE
fix: pin pnpm so GitHub Check can run

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "banner.png"
   ],
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "lint": "oxlint -c .oxlintrc.json",
     "lint:fix": "oxlint -c .oxlintrc.json --fix",


### PR DESCRIPTION
## Summary
- GitHub Check has failed on every run since the repo was created (30/30). `pnpm/action-setup@v4` needs a pnpm version via `version:` or `package.json#packageManager`; the factory workflow shipped neither.
- Pin the local pnpm (`10.33.0`) in the workflow and as `packageManager` so CI can install and actually run `pnpm run check`.

## Test plan
- [ ] Confirm the Check job on this PR gets past `pnpm/action-setup` and runs `pnpm run check`
- [ ] Confirm the job is green (or fails on a real test/lint issue, not missing pnpm)


Made with [Cursor](https://cursor.com)