### PR TITLE
fix: install gitleaks in CI and normalize package.json

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,4 +18,9 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
       - run: pnpm run check

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "banner.png"
   ],
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "lint": "oxlint -c .oxlintrc.json",
     "lint:fix": "oxlint -c .oxlintrc.json --fix",
@@ -66,6 +65,7 @@
   "peerDependencies": {
     "@sinclair/typebox": "*"
   },
+  "packageManager": "pnpm@10.33.0",
   "pi": {
     "extensions": [
       "./src/index.ts"


### PR DESCRIPTION
CI is running now (thanks to #7) but red on main for two environmental reasons:

1. **gitleaks missing**: the `secrets` step exits `gitleaks: not found` — the runner has no gitleaks. Install pinned 8.30.1 binary before `pnpm run check`.
2. **package.json format**: #7's `packageManager` field wasn't in oxfmt's canonical key order; `oxfmt` normalization applied.

This PR's own check run validates the fix end-to-end. Local `pnpm run check`: all green.