### PR TITLE
fix: SSH/.git Brain spec exclusion and phantom nested-branch parents

### DIFF
--- a/src/branches.test.ts
+++ b/src/branches.test.ts
@@ -77,6 +77,16 @@ describe("branchManager", () => {
       expect(fs.existsSync(branchDir)).toBeTruthy();
       expect(manager.branchExists("feature-auth")).toBeTruthy();
     });
+
+    it("does not treat a nested branch's parent directory as a branch", () => {
+      manager.createBranch("feat/auth", "Auth work");
+
+      // "feat" exists on disk only as a container for nested branches; it
+      // has no commits.md, so switching to it would orphan OTA log entries
+      // in a directory no listing ever shows.
+      expect(manager.branchExists("feat")).toBeFalsy();
+      expect(manager.branchExists("feat/auth")).toBeTruthy();
+    });
   });
 
   describe("appendLog", () => {

--- a/src/branches.ts
+++ b/src/branches.ts
@@ -145,7 +145,14 @@ export class BranchManager {
       return false;
     }
 
-    return fs.existsSync(branchDir) && fs.statSync(branchDir).isDirectory();
+    // A branch is a directory with its own commits.md — a nested branch's
+    // parent directory (e.g. "feat" for "feat/auth") is a container, not
+    // a branch, and must not be switchable.
+    return (
+      fs.existsSync(branchDir) &&
+      fs.statSync(branchDir).isDirectory() &&
+      fs.existsSync(path.join(branchDir, "commits.md"))
+    );
   }
 
   getLogSizeBytes(branch: string): number {

--- a/src/committer-extensions.test.ts
+++ b/src/committer-extensions.test.ts
@@ -63,6 +63,28 @@ describe("discoverCommitterExtensionSpecs", () => {
     ).toStrictEqual(["./custom-provider.ts"]);
   });
 
+  it("drops git-URL Brain specs including SSH form and .git suffix", () => {
+    expect(
+      discover([
+        "pi",
+        "-e",
+        "./custom-provider.ts",
+        "-e",
+        "git@github.com:Whamp/pi-brain.git",
+        "-e",
+        "https://github.com/Whamp/pi-brain.git",
+        "-e",
+        "https://github.com/Whamp/pi-brain",
+        // lookalike repo names must NOT be excluded
+        "-e",
+        "git@github.com:Whamp/pi-brain-fork.git",
+      ])
+    ).toStrictEqual([
+      "./custom-provider.ts",
+      "git@github.com:Whamp/pi-brain-fork.git",
+    ]);
+  });
+
   it("reads extensions from project and user settings.json", () => {
     fs.mkdirSync(path.join(cwd, ".pi"), { recursive: true });
     fs.writeFileSync(

--- a/src/committer-extensions.ts
+++ b/src/committer-extensions.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const BRAIN_NPM_SPEC = /^npm:pi-brain(?:@|$)/;
-const BRAIN_GIT_SPEC = /github\.com\/Whamp\/pi-brain(?:\/|$)/i;
+const BRAIN_GIT_SPEC = /github\.com[:/]Whamp\/pi-brain(?:\.git)?(?:[/#]|$)/i;
 
 function extensionSpecsFromArgv(argv: readonly string[]): string[] {
   const specs: string[] = [];

--- a/src/memory-branch.test.ts
+++ b/src/memory-branch.test.ts
@@ -158,6 +158,25 @@ describe("executeMemoryBranch", () => {
     expect(state.activeBranch).toBe("main");
   });
 
+  it("should reject switching to a nested branch's parent directory", () => {
+    executeMemoryBranch(
+      { action: "create", name: "feat/auth", purpose: "Auth work" },
+      state,
+      branches,
+      tmpDir
+    );
+
+    const result = executeMemoryBranch(
+      { action: "switch", branch: "feat" },
+      state,
+      branches,
+      tmpDir
+    );
+
+    expect(result).toContain("not found");
+    expect(state.activeBranch).toBe("feat/auth");
+  });
+
   it("should require branch for switch", () => {
     const result = executeMemoryBranch(
       { action: "switch" },


### PR DESCRIPTION
Delivery-owner verification pass on #6 found two holes; both fixed test-first (red → green).

1. **Brain self-reload via git URL installs**: `isBrainExtensionSpec` only matched `github.com/Whamp/pi-brain/` (literal slash, no `.git`). An install via `git@github.com:Whamp/pi-brain.git` or `https://github.com/Whamp/pi-brain.git` would be forwarded to the committer child, re-enabling the self-append-to-log bug #3 fixed. Regex now covers `:`/`/` separator and `.git` suffix; `pi-brain-fork` lookalikes still pass through.
2. **Phantom nested-branch parents switchable**: `branchExists('feat')` was true when only `feat/auth` existed (dir-without-commits.md), letting OTA writes orphan into an unlisted directory. Branches now require the `commits.md` marker — the same criterion `collectBranchNames` uses.

229 tests green, `pnpm run check` all green, aislop/slop-scan clean.